### PR TITLE
Fix compile error under VS2017 (/Zc:strictStrings)

### DIFF
--- a/gmsrc/src/gm/gmCodeTree.cpp
+++ b/gmsrc/src/gm/gmCodeTree.cpp
@@ -545,7 +545,7 @@ void gmProcessDoubleQuoteString(char * a_string)
 
 
 
-int gmerror(char * a_message)
+int gmerror(const char * a_message)
 {
   gmCodeTree & ct = gmCodeTree::Get();
   if(ct.GetLog())

--- a/gmsrc/src/gm/gmCodeTree.h
+++ b/gmsrc/src/gm/gmCodeTree.h
@@ -253,7 +253,7 @@ struct gmCodeTreeNode
 
 void gmProcessSingleQuoteString(char * a_string);
 void gmProcessDoubleQuoteString(char * a_string);
-int gmerror(char * a_message);
+int gmerror(const char * a_message);
 int gmparse(void);
 
 #endif // _GMCODETREE_H_


### PR DESCRIPTION
/Zc:strictStrings is on by default in VS2017 which lead to a compile error in gmerror, which was being passed a string literal (const char*) as a (char*) argument. This doesn't modify the argument data in any way so can be marked as const char* with no ill-effects.